### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,7 +1,8 @@
 steps:
 - label: run-lint-and-specs-ruby-2.5
   command:
-    - bundle install --jobs=7 --retry=3 --without docs development
+    - bundle config set --local without docs development
+    - bundle install --jobs=7 --retry=3
     - export USER="root"
     - bundle exec rake
   expeditor:
@@ -12,7 +13,8 @@ steps:
 - label: run-lint-and-specs-ruby-2.6
   command:
     - export USER="root"
-    - bundle install --jobs=7 --retry=3 --without docs development
+    - bundle config set --local without docs development
+    - bundle install --jobs=7 --retry=3
     - bundle exec rake
   expeditor:
     executor:

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :test do
   gem "chefstyle", "0.13.0"
   gem "minitest", "~> 5.5"
   gem "rake", ">= 10"
+  gem "chef-utils", "~> 16.6.14"
 end


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
